### PR TITLE
bcr: Don't install for private space

### DIFF
--- a/prebuilts/product/etc/sysconfig/preinstalled-packages-platform-bcr.xml
+++ b/prebuilts/product/etc/sysconfig/preinstalled-packages-platform-bcr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config>
+    <install-in-user-type package="com.chiller3.bcr">
+        <install-in user-type="FULL" />
+        <install-in user-type="PROFILE" />
+        <do-not-install-in user-type="android.os.usertype.profile.CLONE" />
+        <do-not-install-in user-type="android.os.usertype.profile.PRIVATE" />
+    </install-in-user-type>
+</config>


### PR DESCRIPTION
If Private Space has already been enabled, need to delete the Private Space and enable it again, or run: `adb shell pm uninstall --user 10 com.chiller3.bcr`